### PR TITLE
Update to use ipAssetName

### DIFF
--- a/app/(creatorView)/view/[ipOrgId]/[ipAssetId]/AssetDetailCard.tsx
+++ b/app/(creatorView)/view/[ipOrgId]/[ipAssetId]/AssetDetailCard.tsx
@@ -3,9 +3,8 @@ import Link from 'next/link';
 import { cn } from '@/utils';
 import { Skeleton } from '@/components/ui/skeleton';
 import { addHTTPSPrefix } from '@/utils/urlUtils';
-import { IPAsset } from '@story-protocol/core-sdk';
 import AssetDisplayComponent from './AssetDisplayComponent';
-import { MagmaMetaData } from './types';
+import { AssetDetailCardProps } from './types';
 
 const Row = ({ label, children }: { label: string; children: React.ReactNode }) => {
   return (
@@ -42,11 +41,11 @@ export const Fallback = () => (
   </div>
 );
 
-const AssetDetailComponent = async ({ assetInfo }: AssetDetailCardProps) => {
+const AssetDetailComponent = async ({ ipAsset, assetInfo }: AssetDetailCardProps) => {
   return (
     <>
       <Row label="Name">
-        <span className="truncate">{assetInfo.artworkName}</span>
+        <span className="truncate">{ipAsset.name}</span>
       </Row>
 
       <Row label={`Author${assetInfo.authors.length > 1 ? 's' : ''}`}>
@@ -97,14 +96,12 @@ const AssetDetailComponent = async ({ assetInfo }: AssetDetailCardProps) => {
     </>
   );
 };
-type AssetDetailCardProps = {
-  ipAsset: IPAsset;
-  assetInfo: MagmaMetaData;
-};
+
 export default function AssetDetailCard({ ipAsset, assetInfo }: AssetDetailCardProps) {
+  // console.log({ ipAsset, assetInfo });
   return (
     <div className="grid grid-cols-12 gap-6">
-      <AssetDisplayComponent assetInfo={assetInfo} />
+      <AssetDisplayComponent ipAsset={ipAsset} assetInfo={assetInfo} />
       <div className="flex h-full border rounded-xl col-span-12 xl:col-span-7">
         <div className={cn('relative rounded-xl py-2 bg-[rgb(253,253,253)] dark:bg-[#2C2B35] w-full')}>
           <div className="flex items-center justify-between px-6 py-4">

--- a/app/(creatorView)/view/[ipOrgId]/[ipAssetId]/AssetDisplayComponent.tsx
+++ b/app/(creatorView)/view/[ipOrgId]/[ipAssetId]/AssetDisplayComponent.tsx
@@ -3,16 +3,16 @@ import React from 'react';
 import Image from 'next/image';
 import { PuzzlePieceIcon } from '@heroicons/react/24/outline';
 import { getRoundedTime } from '@/utils';
-import { MagmaMetaData } from './types';
+import { AssetDetailCardProps } from './types';
 
-export default function AssetDisplayComponent({ assetInfo }: { assetInfo: MagmaMetaData }) {
+export default function AssetDisplayComponent({ ipAsset, assetInfo }: AssetDetailCardProps) {
   return (
     <div className="flex h-52 md:h-72 xl:h-full col-span-12 xl:col-span-5 rounded-xl bg-indigo-100 overflow-hidden justify-center items-center">
       {assetInfo ? (
         <Image
           width={700}
           height={600}
-          alt={assetInfo.artworkName}
+          alt={ipAsset.name}
           loading="lazy"
           decoding="async"
           data-nimg="1"

--- a/app/(creatorView)/view/[ipOrgId]/[ipAssetId]/page.tsx
+++ b/app/(creatorView)/view/[ipOrgId]/[ipAssetId]/page.tsx
@@ -34,7 +34,6 @@ export default async function AssetDetailPage({ params: { ipAssetId } }: { param
   const { ipAsset } = await storyClient.ipAsset.get({ ipAssetId });
 
   let assetInfo = {
-    artworkName: '',
     description: '',
     authors: [],
     licenseParam: {
@@ -60,17 +59,17 @@ export default async function AssetDetailPage({ params: { ipAssetId } }: { param
 
     const contentType = resp.headers.get('content-type');
 
-    if (contentType?.endsWith('/json')) {
+    if (contentType?.includes('json')) {
       const d = await resp.json();
-      console.log({ d });
+      console.log('TEST', { d });
       assetInfo = {
-        artworkName: d.artworkName || '',
+        artworkName: d.artworkName || ipAsset.name || '',
         description: d.description || '',
         authors: d.authors?.sort((a: Author, b: Author) => b.percentage - a.percentage) || [],
         licenseParam: {
           isCommercial: d.licenseParam?.isCommercial || false,
         },
-        mediaUrl: d.mediaUrl || '',
+        mediaUrl: convertToPreviewUrl(d.mediaUrl) || '',
         origin: d.origin || '',
         originUrl: d.originUrl || '#',
         tags: d.tags || [],
@@ -85,7 +84,7 @@ export default async function AssetDetailPage({ params: { ipAssetId } }: { param
       </div>
       <div className="flex px-10 py-9 w-full max-w-[1280px] flex-col items-left gap-6 mx-auto">
         <div className="flex flex-row gap-4 items-center mb-3">
-          <h1 className="text-[26px] leading-2xl font-bold leading-none">{assetInfo.artworkName}</h1>
+          <h1 className="text-[26px] leading-2xl font-bold leading-none">{ipAsset.name}</h1>
         </div>
         <Suspense fallback={<FallbackDetailsCard />}>
           <AssetDetailCard ipAsset={ipAsset} assetInfo={assetInfo} />

--- a/app/(creatorView)/view/[ipOrgId]/[ipAssetId]/types.ts
+++ b/app/(creatorView)/view/[ipOrgId]/[ipAssetId]/types.ts
@@ -1,3 +1,10 @@
+import { IPAsset } from '@story-protocol/core-sdk';
+
+export type AssetDetailCardProps = {
+  ipAsset: IPAsset;
+  assetInfo: MagmaMetaData;
+};
+
 export type Params = {
   ipAssetId: string;
   ipOrgId: string;
@@ -15,7 +22,7 @@ export type Tag = {
   value: string | number | boolean;
 };
 export type MagmaMetaData = {
-  artworkName: string;
+  artworkName?: string;
   description: string;
   authors: Author[];
   licenseParam: {

--- a/components/cards/AssetCard.tsx
+++ b/components/cards/AssetCard.tsx
@@ -38,6 +38,8 @@ export default function AssetCard({ data }: { data: IPAsset }) {
       });
   }
 
+  console.log({ imageUrl });
+
   return (
     <div className="w-full bg-white rounded-2xl overflow-hidden border-2 border-slate-100 hover:border-indigo-500 hover:shadow-md">
       <span data-state="closed">


### PR DESCRIPTION
- fix bug on checking for contentType `json`
- use `ipAsset.name` instead of `artworkName` from the mediaUrl json